### PR TITLE
Create LikeRepository.java

### DIFF
--- a/SkillConnect-backend/paf-backend-2025/src/main/java/com/example/paf_backend_2025/repositories/LikeRepository.java
+++ b/SkillConnect-backend/paf-backend-2025/src/main/java/com/example/paf_backend_2025/repositories/LikeRepository.java
@@ -1,0 +1,15 @@
+package com.example.paf_backend_2025.repositories;
+
+import com.example.paf_backend_2025.models.Like;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends MongoRepository<Like, String> {
+    List<Like> findByPostId(String postId);
+    List<Like> findByUserId(String userId);
+    Optional<Like> findByUserIdAndPostId(String userId, String postId);
+}


### PR DESCRIPTION
An easy way to interact with the likes collection in MongoDB. It allows finding likes based on post, user, or both together without writing explicit MongoDB queries.